### PR TITLE
Add project support and sponsor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Running fresh model generations is the main cost behind WhichAI.dev. If the gall
 
 ## Sponsors
 
-[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
+<a href="https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source">
+  <img src="https://www.greptile.com/badge.svg" alt="Greptile: The War on Bugs" width="600">
+</a>
 
 [Greptile's Open Source Program](https://www.greptile.com/open-source) provides AI code review for the project.
 

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Running fresh model generations is the main cost behind WhichAI.dev. If the gall
 
 [Greptile's Open Source Program](https://www.greptile.com/open-source) provides AI code review for the project.
 
-**[OpenAI â€” Codex for Open Source](https://openai.com/form/codex-for-oss/)** provides tooling and credits that support open-source maintenance and benchmark development.
+**[OpenAI - Codex for Open Source](https://openai.com/form/codex-for-oss/)** provides tooling and credits that support open-source maintenance and benchmark development.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ Running fresh model generations is the main cost behind WhichAI.dev. If the gall
 
 ## Sponsors
 
-<a href="https://www.greptile.com/open-source">
-  <img src="https://www.greptile.com/wordmark-logo-green.svg" alt="Greptile" height="32">
-</a>
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 [Greptile's Open Source Program](https://www.greptile.com/open-source) provides AI code review for the project.
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@ Look at a generation, guess the model, see if you are right. It is surprisingly 
 Model selection is a design decision. Some models give you solid structure and weak taste. Some produce one gorgeous screen and ignore the rest of the brief. Some completely change character when you toggle a design skill.
 
 WhichAI.dev makes those differences obvious. It is for builders choosing a tool, researchers who want a corpus they can read without a CLI, and anyone who heard AI can build apps and wants a visual answer to "okay, but is it any good at design?"
+
+## Support the Bench
+
+Running fresh model generations is the main cost behind WhichAI.dev. If the gallery helps you choose a model—or you just want to see more models added—you can [buy Dara a coffee](https://www.buymeacoffee.com/daradoescode) to help fund the next batch.
+
+## Sponsors
+
+<a href="https://www.greptile.com/open-source">
+  <img src="https://www.greptile.com/wordmark-logo-green.svg" alt="Greptile" height="32">
+</a>
+
+[Greptile's Open Source Program](https://www.greptile.com/open-source) provides AI code review for the project.
+
+**[OpenAI â€” Codex for Open Source](https://openai.com/form/codex-for-oss/)** provides tooling and credits that support open-source maintenance and benchmark development.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Github } from "lucide-react";
+import { Coffee, Github } from "lucide-react";
 import { GalleryRankingsNav } from "@/components/gallery/gallery-rankings-nav";
 import { GalleryGroupSection } from "@/components/gallery/gallery-group-section";
 import { GenerationPrompt } from "@/components/gallery/generation-prompt";
@@ -66,6 +66,15 @@ export default function HomePage() {
               </svg>
               <span>@daradoescode</span>
             </Link>
+            <Link
+              href="https://www.buymeacoffee.com/daradoescode"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 transition-colors hover:text-[var(--gallery-text-primary)]"
+            >
+              <Coffee className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+              <span>Fund more generations</span>
+            </Link>
           </div>
           <p className="mt-6 text-sm italic text-[var(--gallery-text-quaternary)]">
             This site was designed by Composer 2.0 LOL
@@ -82,6 +91,61 @@ export default function HomePage() {
             );
           })}
         </div>
+
+        <section
+          aria-labelledby="sponsors-heading"
+          className="mt-16 border-t border-[var(--gallery-divider)] pt-8 sm:mt-20 sm:pt-10"
+        >
+          <div className="max-w-2xl">
+            <p className="text-xs font-medium uppercase tracking-[0.16em] text-[var(--gallery-text-quaternary)]">
+              Project support
+            </p>
+            <h2
+              id="sponsors-heading"
+              className="mt-2 text-xl font-medium tracking-tight text-[var(--gallery-text-primary)]"
+            >
+              Sponsors
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-[var(--gallery-text-tertiary)]">
+              These open-source programs help cover the code review and model usage behind
+              WhichAI.dev.
+            </p>
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-stretch gap-3">
+            <a
+              href="https://www.greptile.com/open-source"
+              target="_blank"
+              rel="noreferrer"
+              className="flex min-h-20 min-w-64 flex-1 items-center gap-4 rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-surface)] px-5 py-4 transition-colors hover:border-[var(--gallery-divider-strong)] sm:max-w-sm"
+            >
+              {/* Greptile publishes this wordmark for partner and collaborator embeds. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://www.greptile.com/wordmark-logo-green.svg"
+                alt="Greptile"
+                className="h-6 w-auto max-w-28"
+              />
+              <span className="text-sm leading-snug text-[var(--gallery-text-tertiary)]">
+                Open Source Program
+              </span>
+            </a>
+
+            <a
+              href="https://openai.com/form/codex-for-oss/"
+              target="_blank"
+              rel="noreferrer"
+              className="flex min-h-20 min-w-64 flex-1 items-center gap-4 rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-surface)] px-5 py-4 transition-colors hover:border-[var(--gallery-divider-strong)] sm:max-w-sm"
+            >
+              <span className="text-lg font-semibold tracking-[-0.03em] text-[var(--gallery-text-primary)]">
+                OpenAI
+              </span>
+              <span className="text-sm leading-snug text-[var(--gallery-text-tertiary)]">
+                Codex for Open Source
+              </span>
+            </a>
+          </div>
+        </section>
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -114,17 +114,17 @@ export default function HomePage() {
 
           <div className="mt-5 flex flex-wrap items-stretch gap-3">
             <a
-              href="https://www.greptile.com/open-source"
+              href="https://www.greptile.com/?utm_source=oss_badge&utm_medium=website&utm_campaign=greptile_for_open_source"
               target="_blank"
               rel="noreferrer"
               className="flex min-h-20 min-w-64 flex-1 items-center gap-4 rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-surface)] px-5 py-4 transition-colors hover:border-[var(--gallery-divider-strong)] sm:max-w-sm"
             >
-              {/* Greptile publishes this wordmark for partner and collaborator embeds. */}
+              {/* Greptile publishes this animated OSS badge for project attribution. */}
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src="https://www.greptile.com/wordmark-logo-green.svg"
-                alt="Greptile"
-                className="h-6 w-auto max-w-28"
+                src="https://www.greptile.com/badge.svg"
+                alt="Greptile: The War on Bugs"
+                className="h-5 w-[150px] shrink-0"
               />
               <span className="text-sm leading-snug text-[var(--gallery-text-tertiary)]">
                 Open Source Program

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -117,14 +117,14 @@ export default function HomePage() {
               href="https://www.greptile.com/?utm_source=oss_badge&utm_medium=website&utm_campaign=greptile_for_open_source"
               target="_blank"
               rel="noreferrer"
-              className="flex min-h-20 min-w-64 flex-1 items-center gap-4 rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-surface)] px-5 py-4 transition-colors hover:border-[var(--gallery-divider-strong)] sm:max-w-sm"
+              className="flex min-h-28 min-w-64 flex-1 flex-col items-start justify-center gap-3 rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-surface)] px-5 py-4 transition-colors hover:border-[var(--gallery-divider-strong)] sm:max-w-sm"
             >
               {/* Greptile publishes this animated OSS badge for project attribution. */}
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src="https://www.greptile.com/badge.svg"
                 alt="Greptile: The War on Bugs"
-                className="h-5 w-[150px] shrink-0"
+                className="h-auto w-full max-w-[300px] shrink-0"
               />
               <span className="text-sm leading-snug text-[var(--gallery-text-tertiary)]">
                 Open Source Program


### PR DESCRIPTION
## Summary

- add a compact Buy Me a Coffee link beside the existing creator attribution
- add a responsive sponsors section for Greptile's Open Source Program and OpenAI's Codex for Open Source program
- document both project support and sponsors in the README

The support copy specifically explains that fresh model generations are the main cost behind WhichAI.dev.

## Validation

- `npx eslint src/app/page.tsx`
- `npx next build` (711 static pages generated)
- checked the sponsors section at desktop and iPhone SE widths in both light and dark themes

## Existing repo caveat

The broad `npm run lint` still reports pre-existing violations in preserved/generated benchmark variants; this change introduces no targeted lint findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Fund more generations” link for supporting continued project development.
  * Added a Sponsors section highlighting supporting programs with branding and external links.

* **Documentation**
  * Added donation information to the README.
  * Added sponsor acknowledgments and links to the project documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->