### PR TITLE
Archive Gemini 3.5 Flash gallery entries

### DIFF
--- a/src/lib/gallery-archived.ts
+++ b/src/lib/gallery-archived.ts
@@ -4,6 +4,7 @@ import type { GalleryEntry, ModelSlug } from "@/lib/gallery-types";
 const FORCE_ARCHIVED_MODELS = new Set<ModelSlug>([
   "composer-2.0",
   "composer-2.5",
+  "gemini-3.5-flash",
   "kimi-k-2.6",
   "luna",
   "opus-4.7",

--- a/tests/gallery-routes.spec.ts
+++ b/tests/gallery-routes.spec.ts
@@ -13,6 +13,7 @@ const LATEST_ROUTE_SMOKE_COUNT = 5;
 
 const forceArchivedModels = [
   { model: "composer-2.5", label: "Composer 2.5" },
+  { model: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
   { model: "luna", label: "GPT-5.6 Luna" },
   { model: "terra", label: "GPT-5.6 Terra" },
   { model: "opus-4.8", label: "Opus 4.8" },


### PR DESCRIPTION
## Summary

- hide Gemini 3.5 Flash cards from every gallery group by default
- keep the generations accessible through **Show Archived**
- extend the existing archive visibility regression test to cover Gemini 3.5 Flash

## Validation

- `npx eslint src/lib/gallery-archived.ts tests/gallery-routes.spec.ts`
- `npm run build` — passed; 788 static pages generated
- `npm run test:routes -- --grep "home page hides superseded-generation cards until Show Archived"` — 1 passed

## Existing repo caveat

Repository-wide `npm run lint` still reports the existing legacy/generated variant backlog (163 errors, 74 warnings); both touched files pass targeted ESLint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the gallery home page to consistently treat Gemini 3.5 Flash as archived.
  * Updated gallery route behavior checks to reflect the model’s archived status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->