### PR TITLE
Add configurable gallery switcher docking

### DIFF
--- a/src/components/gallery/variant-header.tsx
+++ b/src/components/gallery/variant-header.tsx
@@ -2,23 +2,38 @@
 
 import clsx from "clsx";
 import Link from "next/link";
-import { Check, Home, Palette, Search } from "lucide-react";
+import { Check, Home, Palette, PanelLeft, PanelRight, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { ModelBrandLogo } from "@/components/gallery/model-brand-logo";
 import { buildCompareHref } from "@/lib/compare";
 import { galleryManifest } from "@/lib/gallery-manifest";
 import { sortGalleryEntriesForHome } from "@/lib/gallery-model-order";
 import type { GalleryEntry, GalleryGroupSlug, IterationId, ModelSlug } from "@/lib/gallery-types";
 import { buildVariantHref } from "@/lib/gallery-paths";
+import {
+  getServerGallerySwitcherSide,
+  getStoredGallerySwitcherSide,
+  setStoredGallerySwitcherSide,
+  subscribeGallerySwitcherSide,
+  type GallerySwitcherSide,
+} from "@/lib/gallery-switcher-side";
 
 type PickerMode = "compare" | "model" | "skill" | null;
 
 const switcherButtonClass =
   "inline-flex size-7 cursor-pointer items-center justify-center rounded-md text-[var(--gallery-text-secondary)] transition-colors outline-none hover:bg-[var(--gallery-hover-bg)] hover:text-[var(--gallery-text-primary)] focus-visible:ring-1 focus-visible:ring-[var(--gallery-accent)]";
 
-const popoverClass =
-  "absolute top-0 right-[calc(100%+0.5rem)] z-[120] flex max-h-[min(26rem,calc(100vh-3rem))] w-[min(19rem,calc(100vw-5.5rem))] flex-col gap-1.5 overflow-auto rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-body-bg)] p-2 text-[var(--gallery-text-primary)] shadow-[var(--gallery-shadow-md)] backdrop-blur-[12px]";
+const popoverBaseClass =
+  "absolute top-0 z-[120] flex max-h-[min(26rem,calc(100vh-3rem))] w-[min(19rem,calc(100vw-5.5rem))] flex-col gap-1.5 overflow-auto rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-body-bg)] p-2 text-[var(--gallery-text-primary)] shadow-[var(--gallery-shadow-md)] backdrop-blur-[12px]";
+
+// Popovers open away from the screen edge the switcher is docked to.
+function getPopoverClass(side: GallerySwitcherSide) {
+  return clsx(
+    popoverBaseClass,
+    side === "left" ? "left-[calc(100%+0.5rem)]" : "right-[calc(100%+0.5rem)]",
+  );
+}
 
 function getGroupLabel(group: GalleryGroupSlug): string {
   if (group === "with-design-skill") return "With Design Skill";
@@ -99,6 +114,13 @@ export function VariantSwitcher({
 }) {
   const router = useRouter();
   const [openPicker, setOpenPicker] = useState<PickerMode>(null);
+  // Docked side is a stored preference; the server snapshot keeps hydration in sync.
+  const side = useSyncExternalStore(
+    subscribeGallerySwitcherSide,
+    getStoredGallerySwitcherSide,
+    getServerGallerySwitcherSide,
+  );
+  const popoverClass = getPopoverClass(side);
   const [compareSearch, setCompareSearch] = useState("");
   const [modelSearch, setModelSearch] = useState("");
   const pickerRef = useRef<HTMLElement | null>(null);
@@ -148,6 +170,10 @@ export function VariantSwitcher({
   }, [modelOptions, modelSearch]);
   const firstAvailableCompareMatch = filteredCompareOptions.find((option) => option.href);
   const firstAvailableModelMatch = filteredModelOptions.find((option) => option.href);
+
+  function toggleSide() {
+    setStoredGallerySwitcherSide(side === "left" ? "right" : "left");
+  }
 
   useEffect(() => {
     if (!openPicker) return;
@@ -217,7 +243,11 @@ export function VariantSwitcher({
     <nav
       ref={pickerRef}
       aria-label={`${entry.modelLabel} gallery navigation`}
-      className="gallery-variant-switcher fixed top-5 right-5 z-[100] flex w-auto flex-col items-center gap-1 rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-nav-bg)] px-1 py-1 text-[var(--gallery-text-tertiary)] shadow-[var(--gallery-shadow-sm)] backdrop-blur-[12px] sm:top-6 sm:right-6 gallery-elevated-surface"
+      data-side={side}
+      className={clsx(
+        "gallery-variant-switcher gallery-elevated-surface fixed top-5 z-[100] flex w-auto flex-col items-center gap-1 rounded-lg border border-[var(--gallery-border)] bg-[var(--gallery-nav-bg)] px-1 py-1 text-[var(--gallery-text-tertiary)] shadow-[var(--gallery-shadow-sm)] backdrop-blur-[12px] sm:top-6",
+        side === "left" ? "left-5 sm:left-6" : "right-5 sm:right-6",
+      )}
     >
       <Link
         href="/"
@@ -528,6 +558,23 @@ export function VariantSwitcher({
           );
         })}
       </div>
+      <div
+        className="h-px w-full shrink-0 bg-[var(--gallery-border)]"
+        aria-hidden="true"
+      />
+      <button
+        type="button"
+        onClick={toggleSide}
+        aria-label={side === "left" ? "Dock sidebar on the right" : "Dock sidebar on the left"}
+        title={side === "left" ? "Dock right" : "Dock left"}
+        className={switcherButtonClass}
+      >
+        {side === "left" ? (
+          <PanelRight className="size-4 shrink-0 opacity-80" aria-hidden="true" />
+        ) : (
+          <PanelLeft className="size-4 shrink-0 opacity-80" aria-hidden="true" />
+        )}
+      </button>
     </nav>
   );
 }

--- a/src/lib/gallery-switcher-side.ts
+++ b/src/lib/gallery-switcher-side.ts
@@ -1,0 +1,56 @@
+export const GALLERY_SWITCHER_SIDE_STORAGE_KEY = "gallery-switcher-side";
+
+export type GallerySwitcherSide = "left" | "right";
+
+export const DEFAULT_GALLERY_SWITCHER_SIDE: GallerySwitcherSide = "right";
+
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+export function getStoredGallerySwitcherSide(): GallerySwitcherSide {
+  if (typeof window === "undefined") {
+    return DEFAULT_GALLERY_SWITCHER_SIDE;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(GALLERY_SWITCHER_SIDE_STORAGE_KEY);
+    if (stored === "left" || stored === "right") {
+      return stored;
+    }
+  } catch {
+    // Ignore storage errors and fall back to the default side.
+  }
+
+  return DEFAULT_GALLERY_SWITCHER_SIDE;
+}
+
+export function getServerGallerySwitcherSide(): GallerySwitcherSide {
+  return DEFAULT_GALLERY_SWITCHER_SIDE;
+}
+
+export function setStoredGallerySwitcherSide(side: GallerySwitcherSide) {
+  try {
+    window.localStorage.setItem(GALLERY_SWITCHER_SIDE_STORAGE_KEY, side);
+  } catch {
+    // Ignore storage errors; subscribers still get the new side for this session.
+  }
+
+  notify();
+}
+
+export function subscribeGallerySwitcherSide(listener: () => void) {
+  listeners.add(listener);
+
+  function handleStorage(event: StorageEvent) {
+    if (event.key === null || event.key === GALLERY_SWITCHER_SIDE_STORAGE_KEY) listener();
+  }
+
+  window.addEventListener("storage", handleStorage);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", handleStorage);
+  };
+}

--- a/tests/gallery-routes.spec.ts
+++ b/tests/gallery-routes.spec.ts
@@ -314,6 +314,44 @@ test("gallery switcher text colors stay isolated from generated variant CSS", as
   expect(["#fff", "#ffffff"]).toContain(cssVariables.generationBackground);
 });
 
+test("gallery switcher can dock on the left and remembers the side", async ({ page }) => {
+  await page.goto("/with-design-skill/gpt-5.5-high/1");
+
+  const switcher = page.getByRole("navigation", { name: /gallery navigation/ });
+  await expect(switcher).toBeVisible();
+  await expect(switcher).toHaveAttribute("data-side", "right");
+
+  const viewportWidth = page.viewportSize()?.width ?? 0;
+  const rightBox = await switcher.boundingBox();
+  expect(rightBox).not.toBeNull();
+  expect(rightBox!.x).toBeGreaterThan(viewportWidth / 2);
+
+  await page.getByRole("button", { name: "Dock sidebar on the left" }).click();
+  await expect(switcher).toHaveAttribute("data-side", "left");
+
+  const leftBox = await switcher.boundingBox();
+  expect(leftBox).not.toBeNull();
+  expect(leftBox!.x).toBeLessThan(viewportWidth / 2);
+
+  // Popovers open away from the docked edge so they stay on screen.
+  await page.getByRole("button", { name: /Switch model from/ }).click();
+  const menu = page.getByRole("menu", { name: "Switch model" });
+  await expect(menu).toBeVisible();
+  const menuBox = await menu.boundingBox();
+  expect(menuBox).not.toBeNull();
+  expect(menuBox!.x).toBeGreaterThan(leftBox!.x + leftBox!.width);
+  await page.keyboard.press("Escape");
+
+  await page.reload();
+  await expect(switcher).toHaveAttribute("data-side", "left");
+  await expect(
+    page.getByRole("link", { name: "Open iteration 2" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Dock sidebar on the right" }).click();
+  await expect(switcher).toHaveAttribute("data-side", "right");
+});
+
 for (const { group, model, iteration, source } of routeSmokeCases) {
   const entry = galleryManifest.find((item) => item.group === group && item.model === model);
   if (!entry) {


### PR DESCRIPTION
## Summary

- Add a persistent control to dock the gallery switcher on the left or right.
- Position switcher popovers away from the docked edge.
- Add end-to-end coverage for docking, persistence, and popover placement.

## Testing

- Added Playwright coverage for left/right docking and local-storage persistence.
- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gallery switcher can now be docked on either the left or right side of the screen.
  * Added a control to switch the docked side, with the preference preserved after page reloads and synchronized across tabs.
  * Model-selection popovers automatically position themselves based on the selected docked side.

* **Bug Fixes**
  * Improved gallery switcher positioning and popover placement for left-side docking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->